### PR TITLE
autofocus on searchbar when toggled

### DIFF
--- a/lib/Views/SearchView.html
+++ b/lib/Views/SearchView.html
@@ -1,6 +1,6 @@
 <atom-panel v-on:keyup.esc="close" v-on:keyup.up="up" v-on:keyup.down="down" v-on:keyup.left="play" v-on:keyup.right="play" class='modal'>
     <div class='select-list'>
-        <input class="user-input native-key-bindings" type="text" v-model="query" v-on:keyup.enter="search">
+        <input id="yt-searchbar" class="user-input native-key-bindings" type="text" v-model="query" v-on:keyup.enter="search">
         <div v-show="state == 'initial'">Search your video, and we will display the results.</div>
        <div v-show="state == 'loading'" class='loading'>
           <span class='loading-message'>Searching in youtube.</span>

--- a/lib/playyoutube-atom.coffee
+++ b/lib/playyoutube-atom.coffee
@@ -109,6 +109,7 @@ module.exports = PlayyoutubeAtom =
       @SearchFrameVisibility(false)
     else
       @SearchFrameVisibility(true)
+      document.getElementById('yt-searchbar').focus()
 
   VideoFrameVisibility: (visible) ->
     if(visible)


### PR DESCRIPTION
When bringing up the search bar, you need to click it in order to type or have the `Esc` key recognized. This PR focuses the input whenever it is toggled visible.